### PR TITLE
Return 404 instead of 403 for objects that do not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Entries are derived from the Git tags of this repository.
 > Note: releases up to `v0.0.39` were tagged with a `v` prefix; from `0.0.40`
 > onward the prefix was dropped.
 
+## [0.1.8] - 2026-08-06
+### Changed
+- Grant the CloudFront service principal `s3:ListBucket` on the bucket, so a request for an
+  object that does not exist returns `404` instead of `403`. Previously a missing object and a
+  rejected signature were indistinguishable to both viewers and log analysis.
+
 ## [0.1.7] - 2026-03-05
 ### Fixed
 - Correct default value for `cloudfront_logging_config`.

--- a/bucket.tf
+++ b/bucket.tf
@@ -14,6 +14,31 @@ data "aws_iam_policy_document" "bucket" {
       values   = concat([module.default_cloudfront.cloudfront_distribution_arn], var.bucket_additional_cloudfront_arns)
     }
   }
+
+  # Without s3:ListBucket, S3 answers a GetObject for a key that does not exist with
+  # AccessDenied rather than NoSuchKey, and CloudFront surfaces that to the viewer as 403.
+  # A missing object is then indistinguishable from a rejected signature, which makes both
+  # undiagnosable: the same status covers "this content is gone" and "this URL is not valid".
+  #
+  # Granting it does not let anyone enumerate the bucket. CloudFront never issues ListBucket
+  # on a viewer's behalf and exposes no listing operation, and the grant stays restricted to
+  # the CloudFront service principal for these distributions only. The single effect is that
+  # an absent key now returns 404 instead of 403.
+  statement {
+    sid    = "AllowCloudFrontServicePrincipalDistinguishMissingObjects"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+    actions   = ["s3:ListBucket"]
+    resources = ["arn:aws:s3:::${var.bucket_name}"]
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = concat([module.default_cloudfront.cloudfront_distribution_arn], var.bucket_additional_cloudfront_arns)
+    }
+  }
 }
 
 module "bucket" {


### PR DESCRIPTION
The bucket policy granted the CloudFront service principal only s3:GetObject. Without s3:ListBucket, S3 answers a GetObject for a key that does not exist with AccessDenied rather than NoSuchKey, and CloudFront passes that on to the viewer as 403. A missing object was therefore indistinguishable from a rejected signature: one status code covered both "this content is gone" and "this URL is not valid", for viewers and for access-log analysis alike.

Add a second statement granting s3:ListBucket on the bucket ARN, restricted to the same CloudFront service principal and the same AWS:SourceArn condition as the existing GetObject grant.

This does not allow anyone to enumerate the bucket. CloudFront never issues ListBucket on a viewer's behalf and exposes no listing operation to clients, and the grant remains scoped to the distributions named in the condition. The only observable change is that an absent key now returns 404 rather than 403, which discloses object existence to a caller who already holds a valid signed URL.

Two consequences for consumers of this module:

  * Clients that treat 403 as "credentials expired, retry" will now see 404 for missing content and should treat it as terminal.
  * The module sets no custom_error_response, so CloudFront's default error caching applies to the new 404 responses.