### PR TITLE
Raise Tachyon memory and make it configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Entries are derived from the Git tags of this repository.
 > Note: releases up to `v0.0.39` were tagged with a `v` prefix; from `0.0.40`
 > onward the prefix was dropped.
 
+## [0.1.9] - 2026-08-10
+### Changed
+- Raise the default Tachyon memory from 512 MB to 2048 MB, and expose it as `tachyon_memory_size`.
+  512 MB is not enough for larger source images: decoding an original into a bitmap needs far more memory than
+  the encoded file size suggests, and on exceeding its allocation Lambda kills the function rather than letting
+  it return an error. Because Tachyon runs as an origin-request Lambda@Edge, CloudFront has by then accepted
+  the viewer connection and has nothing to send, so callers see a connected but silent socket until the 30s
+  timeout expires rather than a failure they can act on.
+  Lambda CPU scales with memory, so this also cuts resize duration; for CPU-bound work the billed GB-ms should
+  stay roughly flat. **Applying this republishes the Lambda@Edge version and triggers a CloudFront
+  distribution deployment, which takes a few minutes to propagate.**
+
 ## [0.1.8] - 2026-08-06
 ### Changed
 - Grant the CloudFront service principal `s3:ListBucket` on the bucket, so a request for an

--- a/lambdas.tf
+++ b/lambdas.tf
@@ -1,5 +1,6 @@
 module "lambdas" {
-  source      = "./modules/lambdas"
-  bucket_name = var.bucket_name
-  bucket_arn  = module.bucket.s3_bucket_arn
+  source              = "./modules/lambdas"
+  bucket_name         = var.bucket_name
+  bucket_arn          = module.bucket.s3_bucket_arn
+  tachyon_memory_size = var.tachyon_memory_size
 }

--- a/modules/lambdas/tachyon.tf
+++ b/modules/lambdas/tachyon.tf
@@ -27,15 +27,17 @@ data "aws_iam_policy_document" "tachyon_bucket" {
 }
 
 module "tachyon" {
-  source                            = "terraform-aws-modules/lambda/aws"
-  version                           = "8.7.0"
-  region                            = "us-east-1"
-  function_name                     = "tachyon-${var.bucket_name}"
-  description                       = "Lambda@Edge Tachyon for ${var.bucket_name}"
-  handler                           = "lambda-handler.handler"
-  runtime                           = "nodejs22.x"
+  source        = "terraform-aws-modules/lambda/aws"
+  version       = "8.7.0"
+  region        = "us-east-1"
+  function_name = "tachyon-${var.bucket_name}"
+  description   = "Lambda@Edge Tachyon for ${var.bucket_name}"
+  handler       = "lambda-handler.handler"
+  runtime       = "nodejs22.x"
+  # 30s is the hard ceiling AWS allows for an origin-request Lambda@Edge, so this cannot be raised.
+  # Resizing must fit inside it - see tachyon_memory_size, which is the lever that actually helps.
   timeout                           = 30
-  memory_size                       = 512
+  memory_size                       = var.tachyon_memory_size
   lambda_at_edge                    = true
   publish                           = true
   create_package                    = false

--- a/modules/lambdas/variables.tf
+++ b/modules/lambdas/variables.tf
@@ -9,3 +9,34 @@ variable "bucket_name" {
 variable "bucket_arn" {
   type = string
 }
+
+// ==========================================================================================================================
+// Tachyon
+// ==========================================================================================================================
+
+variable "tachyon_memory_size" {
+  description = <<-EOT
+    Memory in MB for the Tachyon image-resizing Lambda@Edge.
+
+    Image resizing is memory-hungry: decoding an original into a bitmap needs far more memory than the
+    encoded file size suggests, so even a modest source image can exhaust a small allocation. When the
+    function exceeds its allocation Lambda kills it rather than letting it return an error.
+
+    That matters more here than for an ordinary Lambda. As an origin-request function it sits between the
+    viewer and the origin, so while it is stuck CloudFront has accepted the viewer connection and has
+    nothing to send. Callers see a connected but silent socket until the timeout expires, and any client
+    without its own read timeout will hang for the full duration. Headroom here is worth more than the
+    memory it costs.
+
+    Lambda CPU scales with memory, so this also governs resize duration; for CPU-bound work the billed
+    GB-ms stays roughly flat as memory rises and duration falls. Raise it further for buckets holding
+    unusually large originals.
+  EOT
+  type        = number
+  default     = 2048
+
+  validation {
+    condition     = var.tachyon_memory_size >= 512
+    error_message = "tachyon_memory_size must be at least 512 MB; below that Tachyon cannot resize typical originals."
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -44,6 +44,20 @@ variable "bucket_automatic_cleanup_multipart_upload_days" {
 }
 
 // ==========================================================================================================================
+// Tachyon
+// ==========================================================================================================================
+
+variable "tachyon_memory_size" {
+  description = <<-EOT
+    Memory in MB for the Tachyon image-resizing Lambda@Edge. Raise this for buckets holding unusually large
+    originals: Lambda CPU scales with memory, so it governs both out-of-memory kills and resize duration.
+    512 MB is not enough for larger source images.
+  EOT
+  type        = number
+  default     = 2048
+}
+
+// ==========================================================================================================================
 // Cloudfront
 // ==========================================================================================================================
 


### PR DESCRIPTION
512 MB is not enough for larger source images. Decoding an original into a bitmap needs far more memory than the encoded file size suggests, and on exceeding its allocation Lambda kills the function rather than letting it return an error.

That matters more for an origin-request Lambda@Edge than for an ordinary function. CloudFront has by then accepted the viewer connection and has nothing to send, so callers see a connected but silent socket until the timeout expires. A client without its own read timeout hangs for the full duration rather than getting a failure it can act on.

Default to 2048 MB and expose it as tachyon_memory_size so buckets with unusually large originals can go higher. Lambda CPU scales with memory, so this cuts resize duration as well as the out-of-memory kills; for CPU-bound work the billed GB-ms should stay roughly flat.

The 30s timeout is left alone because it is the hard ceiling AWS allows for an origin-request Lambda@Edge. Memory is the only lever, which is now noted next to it.