### PR TITLE
Keep the attribution query parameters out of the cache key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ Entries are derived from the Git tags of this repository.
 > Note: releases up to `v0.0.39` were tagged with a `v` prefix; from `0.0.40`
 > onward the prefix was dropped.
 
+## [0.1.10] - 2026-08-21
+### Changed
+- Keep the attribution query parameters `appId` and `platform` out of the CloudFront cache key and out of the
+  origin request policy. They exist only to attribute traffic in access-log analysis: neither changes the object
+  returned - the request path is the S3 key - and CloudFront records the query string verbatim in the access log
+  whether or not it is part of the cache key. Keying on them split the cache across values that all resolve to
+  the same object, which cost hit rate on exactly the small, frequently requested objects where it matters most.
+  The exclusion is unconditional and no longer tied to `cloudfront_exclude_tracking_params`, which now covers
+  only third-party click-tracking parameters. As a result `query_string_behavior` is always `allExcept`, where
+  it was `all` for callers that left that variable at its default. Parameters that do change the response -
+  `response-content-disposition` and the Tachyon image parameters `w`/`h`/`webp`/`quality`/`crop` - stay in the
+  cache key. **Applying this updates the cache and origin request policies in place - their ids do not change,
+  so attached distributions are not replaced - and triggers a CloudFront distribution deployment; cached objects
+  are re-keyed, so expect a brief dip in hit rate before it settles above the previous level.**
+
 ## [0.1.9] - 2026-08-10
 ### Changed
 - Raise the default Tachyon memory from 512 MB to 2048 MB, and expose it as `tachyon_memory_size`.

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -7,6 +7,46 @@ resource "aws_cloudfront_public_key" "purple" {
   }
 }
 
+locals {
+  # Query parameters that exist only to attribute traffic in access-log analysis. They never change
+  # the object returned - the request path is the S3 key - and CloudFront records the query string
+  # verbatim in the access log whether or not it is part of the cache key. Keying on them therefore
+  # buys nothing and splits the cache across values that all resolve to the same object, which costs
+  # hit rate on exactly the small, frequently requested objects where it matters most. So they are
+  # excluded unconditionally, independently of `cloudfront_exclude_tracking_params`.
+  #
+  # The rule for anything added here: a parameter that only describes the caller does not belong in
+  # the cache key, and a parameter that changes the response has to stay in it -
+  # `response-content-disposition` sets a response header, and the Tachyon image parameters
+  # (`w`, `h`, `webp`, `quality`, `crop`) change the returned image. That is why this is a deny-list
+  # and must not be inverted into an allow-list.
+  cloudfront_attribution_query_params = [
+    "appId",
+    "platform",
+  ]
+
+  # Click-tracking parameters. Unlike the attribution parameters these are set by third parties on
+  # inbound links, so dropping them stays an opt-in per distribution.
+  cloudfront_tracking_query_params = [
+    "fbclid",
+    "gclid",
+    "utm_campaign",
+    "utm_medium",
+    "utm_source",
+    "utm_term",
+    "msclkid",
+    "_ga",
+    "mc_cid",
+    "dclid",
+  ]
+
+  # `allExcept` requires a non-empty item list; the attribution parameters guarantee one.
+  cloudfront_excluded_query_params = concat(
+    local.cloudfront_attribution_query_params,
+    var.cloudfront_exclude_tracking_params ? local.cloudfront_tracking_query_params : [],
+  )
+}
+
 resource "aws_cloudfront_cache_policy" "s3" {
   name        = var.bucket_name
   min_ttl     = 1
@@ -28,23 +68,9 @@ resource "aws_cloudfront_cache_policy" "s3" {
       }
     }
     query_strings_config {
-      query_string_behavior = var.cloudfront_exclude_tracking_params ? "allExcept" : "all"
-      dynamic "query_strings" {
-        for_each = var.cloudfront_exclude_tracking_params ? [1] : []
-        content {
-          items = [
-            "fbclid",
-            "gclid",
-            "utm_campaign",
-            "utm_medium",
-            "utm_source",
-            "utm_term",
-            "msclkid",
-            "_ga",
-            "mc_cid",
-            "dclid"
-          ]
-        }
+      query_string_behavior = "allExcept"
+      query_strings {
+        items = local.cloudfront_excluded_query_params
       }
     }
     enable_accept_encoding_brotli = false
@@ -69,23 +95,9 @@ resource "aws_cloudfront_origin_request_policy" "s3" {
     }
   }
   query_strings_config {
-    query_string_behavior = var.cloudfront_exclude_tracking_params ? "allExcept" : "all"
-    dynamic "query_strings" {
-      for_each = var.cloudfront_exclude_tracking_params ? [1] : []
-      content {
-        items = [
-          "fbclid",
-          "gclid",
-          "utm_campaign",
-          "utm_medium",
-          "utm_source",
-          "utm_term",
-          "msclkid",
-          "_ga",
-          "mc_cid",
-          "dclid"
-        ]
-      }
+    query_string_behavior = "allExcept"
+    query_strings {
+      items = local.cloudfront_excluded_query_params
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -98,7 +98,7 @@ variable "cloudfront_logging_config" {
 }
 
 variable "cloudfront_exclude_tracking_params" {
-  description = "Exclude common tracking parameters (utm_*, fbclid, gclid, etc.) from CloudFront cache key to improve cache hit rates for social media traffic"
+  description = "Exclude common third-party click-tracking parameters (utm_*, fbclid, gclid, etc.) from the CloudFront cache key to improve cache hit rates for social media traffic. The attribution parameters (appId, platform) are always excluded from the cache key and are not affected by this toggle."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
`appId` and `platform` exist only to attribute traffic in access-log analysis. Neither changes the object returned - the request path is the S3 key - and CloudFront records the query string verbatim in the access log whether or not it is part of the cache key. Keying on them therefore buys nothing and splits the cache across values that all resolve to the same object, which costs hit rate on exactly the small, frequently requested objects where it matters most.

The exclusion is unconditional rather than tied to `cloudfront_exclude_tracking_params`: a parameter that only describes the caller has no business in a cache key, regardless of how a distribution feels about click-tracking parameters. That variable now covers only the third-party tracking parameters, which stay opt-in because they arrive on inbound links rather than from the application.

`query_string_behavior` is therefore always `allExcept`, where it was `all` for callers on the default. This stays a deny-list on purpose: `response-content-disposition` sets a response header and the Tachyon image parameters `w`/`h`/`webp`/`quality`/`crop` change the returned image, so both must remain in the key.